### PR TITLE
CLI warning on single-word repository argument

### DIFF
--- a/exe/how_is
+++ b/exe/how_is
@@ -19,12 +19,21 @@ opts      = result[:opts]
 options   = result[:options]
 arguments = result[:arguments]
 
-if options[:help]
-  puts result[:opts]
-elsif options[:version]
-  puts HowIs::VERSION
-elsif options[:config]
-  HowIs::CLI.new.from_config_file(options[:config])
-else
-  HowIs.generate_report_file(options)
+begin
+  if options[:help]
+    puts result[:opts]
+  elsif options[:version]
+    puts HowIs::VERSION
+  elsif options[:config]
+    HowIs::CLI.new.from_config_file(options[:config])
+  else
+    HowIs.generate_report_file(options)
+  end
+rescue => e
+  if ENV['SHOW_TRACE']
+    raise
+  else
+    abort "Error: #{e.message}"
+  end
 end
+

--- a/lib/how_is/fetcher.rb
+++ b/lib/how_is/fetcher.rb
@@ -31,6 +31,9 @@ class HowIs::Fetcher
         github = nil)
     github ||= Github.new(auto_pagination: true)
     user, repo = repository.split('/', 2)
+    raise HowIs::CLI::OptionsError, 'To generate a report from GitHub, ' \
+                                    'provide the repository username/project. ' \
+                                    'Quitting!' unless user && repo
     issues  = github.issues.list user: user, repo: repo
     pulls   = github.pulls.list  user: user, repo: repo
 


### PR DESCRIPTION
This PR adds a CLI error message when the confused user enters the repository name as `puma` instead of `puma/puma`.