### PR TITLE
Unpin Rack version.

### DIFF
--- a/how_is.gemspec
+++ b/how_is.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "contracts", "~> 0.14.0"
   spec.add_runtime_dependency "slop", "~> 4.4.1"
 
-  spec.add_runtime_dependency "rack", "~> 2.0"
-
   spec.add_runtime_dependency "tessellator-fetcher", "~> 5.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
The Rack version was previously pinned to < 2.0 for compatibility
with Ruby 2.2.0. We no longer need to support 2.2.0, so we can
get out of the way and let the OAuth gem specify the rack version
itself.