### PR TITLE
exe/how_is: Reinstate to_json, to_html

### DIFF
--- a/exe/how_is
+++ b/exe/how_is
@@ -2,7 +2,6 @@
 
 require "how_is"
 require "how_is/cli"
-require "pathname"
 
 begin
   parser  = HowIs::CLI::Parser.new
@@ -15,9 +14,7 @@ rescue HowIs::CLI::OptionsError => e
   end
 end
 
-opts      = result[:opts]
-options   = result[:options]
-arguments = result[:arguments]
+options = result[:options]
 
 if options[:help]
   puts result[:opts]
@@ -27,20 +24,11 @@ elsif options[:version]
   exit
 end
 
-def save_files(reports)
-  reports.each do |file, report|
-    report_format = Pathname(file).extname.delete('.')
-    File.open(file, 'w') do |f|
-      f.write report.public_send("to_#{report_format}")
-    end
-  end
-end
-
 begin
   if options[:config]
     reports = HowIs.from_config(YAML.load_file(options[:config]))
 
-    save_files(reports)
+    reports.each { |file, report| HowIs::Report.save_report(file, report) }
   else
     report =
       if options[:from]
@@ -50,7 +38,10 @@ begin
         HowIs.new(options[:repository])
       end
 
-    save_files({ options[:report] => report })
+    HowIs::Report.save_report(
+      options[:report],
+      HowIs::Report.to_format_based_on(options[:report], report)
+    )
   end
 
 rescue => e

--- a/exe/how_is
+++ b/exe/how_is
@@ -2,6 +2,7 @@
 
 require "how_is"
 require "how_is/cli"
+require "pathname"
 
 begin
   parser  = HowIs::CLI::Parser.new
@@ -28,10 +29,9 @@ end
 
 def save_files(reports)
   reports.each do |file, report|
-    format = file.split('.').last
-
+    report_format = Pathname(file).extname.delete('.')
     File.open(file, 'w') do |f|
-      f.write report
+      f.write report.public_send("to_#{report_format}")
     end
   end
 end

--- a/lib/how_is.rb
+++ b/lib/how_is.rb
@@ -33,7 +33,7 @@ class HowIs
   ##
   # Generate an HTML report.
   #
-  # @returns [String] An HTML report.
+  # @return [String] An HTML report.
   def to_html
     Report.export(@analysis, :html)
   end
@@ -41,7 +41,7 @@ class HowIs
   ##
   # Generate a JSON report.
   #
-  # @returns [String] A JSON report.
+  # @return [String] A JSON report.
   def to_json
     Report.export(@analysis, :json)
   end
@@ -51,7 +51,7 @@ class HowIs
   # reports).
   #
   # @param json [String] A JSON report object.
-  # @returns [HowIs] A HowIs object that can be used for generating other
+  # @return [HowIs] A HowIs object that can be used for generating other
   #   reports, treating the JSON report as a cache.
   def self.from_json(json)
     self.from_hash(JSON.parse(json))
@@ -62,7 +62,7 @@ class HowIs
   # other reports).
   #
   # @param data [Hash] A hash containing report data.
-  # @returns [HowIs] A HowIs object that can be used for generating other
+  # @return [HowIs] A HowIs object that can be used for generating other
   #   reports, treating the provided report data as a cache.
   def self.from_hash(data)
     analysis = HowIs::Analyzer.from_hash(data)
@@ -73,7 +73,7 @@ class HowIs
   ##
   # Returns a list of possible export formats.
   #
-  # @returns [Array<String>] An array of the types of reports you can
+  # @return [Array<String>] An array of the types of reports you can
   #   generate.
   def self.supported_formats
     report_constants = HowIs.constants.grep(/.Report/) - [:BaseReport]
@@ -84,7 +84,7 @@ class HowIs
   # Returns whether or not the specified +file+ can be exported to.
   #
   # @param file [String] A filename.
-  # @returns [Boolean] +true+ if HowIs can export to the file, +false+
+  # @return [Boolean] +true+ if HowIs can export to the file, +false+
   #   if it can't.
   def self.can_export_to?(file)
     # TODO: Check if the file is writable?

--- a/lib/how_is/report.rb
+++ b/lib/how_is/report.rb
@@ -1,4 +1,5 @@
 require 'date'
+require "pathname"
 
 class HowIs
   class UnsupportedExportFormat < StandardError
@@ -26,6 +27,40 @@ class HowIs
       report = get_report_class(format).new(analysis)
 
       report.export
+    end
+
+    ##
+    # Saves given Report in given file.
+    #
+    # @param file [String,Pathname] Name of file to write to
+    # @param report [Report] Report to store
+    def self.save_report(file, report)
+      File.open(file, 'w') do |f|
+        f.write report
+      end
+    end
+
+    ##
+    # Returns the report format for given filename.
+    #
+    # @param file [String] Filename of a report
+    #
+    # @return [String] Report format inferred from file name
+    def self.infer_format(file)
+      Pathname(file).extname.delete('.')
+    end
+
+    ##
+    # Exports given +report+ to the format suitable for given +file+.
+    #
+    # @param file [String,Pathname]
+    # @param report [Report]
+    #
+    # @return [String] The rendered report
+    def self.to_format_based_on(file, report)
+      report_format = infer_format(file)
+
+      report.public_send("to_#{report_format}")
     end
 
   private

--- a/lib/how_is/report/base_report.rb
+++ b/lib/how_is/report/base_report.rb
@@ -43,7 +43,7 @@ class HowIs
     ##
     # Returns the format of report this class generates.
     #
-    # @returns [Symbol] A lowercase symbol denoting the report format.
+    # @return [Symbol] A lowercase symbol denoting the report format.
     def format
       raise NotImplementedError
     end


### PR DESCRIPTION
  - Fixes #149 
  - Avoids using the [`format`](https://ruby-doc.org/core-2.4.0/Kernel.html#method-i-format) name
  - And then, reworked to ideas in #149 comments ✨ 😍 