### PR TITLE
Gemfile: use Hashie from master branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in how_is.gemspec
 gemspec
+gem 'hashie', git: 'https://github.com/intridea/hashie.git'


### PR DESCRIPTION
This PR avoids outputting a Ruby warning in test runs by using Hashie from `master` until the fix https://github.com/intridea/hashie/pull/416 has been released as v3.5.6.

Effect of using this: it avoids a Ruby warning in spec output.