### PR TITLE
Rubocop 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,6 +88,17 @@ Layout/EndOfLine:
 Layout/ExtraSpacing:
   Enabled: false
 
+#   # bad
+#
+#   format('%<greeting>s', greeting: 'Hello')
+#   format('%s', 'Hello')
+#
+#   # good
+#
+#   format('%{greeting}', greeting: 'Hello')
+Style/FormatStringToken:
+  EnforcedStyle: template
+
 # Freeze string literals to future-proof the code.
 # TODO: Enable this always. (Disabled due to not knowing what will happen.)
 Style/FrozenStringLiteralComment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 
 # Most readable form.
-Style/AlignHash:
+Layout/AlignHash:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
   # Disable because it wound up conflicting with a lot of things like:
@@ -50,7 +50,7 @@ Style/AlignHash:
   # addressed.
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   # See Style/AlignedHash.
   Enabled: false
 
@@ -74,7 +74,7 @@ Style/Encoding:
   Enabled: true
 
 # Force Unix line endings.
-Style/EndOfLine:
+Layout/EndOfLine:
   Enabled: true
   EnforcedStyle: lf
 
@@ -85,7 +85,7 @@ Style/EndOfLine:
 # foobar = 'blah'
 # baz    = 'asdf'
 # beep   = 'boop'
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Enabled: false
 
 # Freeze string literals to future-proof the code.
@@ -133,11 +133,11 @@ Style/MethodCalledOnDoEndBlock:
 
 # Indenting the chained dots beneath each other is not supported by this cop,
 # see https://github.com/bbatsov/rubocop/issues/1633
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 # {'foo' => 'bar'} not { 'foo' => 'bar' }
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: true
   EnforcedStyle: no_space
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
     openssl-better_defaults (0.0.1)
+    parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -70,7 +71,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.47.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -101,7 +103,7 @@ DEPENDENCIES
   how_is!
   rake (~> 11.2)
   rspec (~> 3.5)
-  rubocop (~> 0.47.0)
+  rubocop (~> 0.49.1)
   timecop (~> 0.8.1)
   vcr (~> 3.0)
   webmock

--- a/exe/how_is
+++ b/exe/how_is
@@ -51,4 +51,3 @@ rescue => e
     abort "Error: #{e.message}"
   end
 end
-

--- a/how_is.gemspec
+++ b/how_is.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.8.1"
   spec.add_development_dependency "vcr", "~> 3.0"
   spec.add_development_dependency "webmock"
-  spec.add_development_dependency "rubocop", "~> 0.47.0"
+  spec.add_development_dependency "rubocop", "~> 0.49.1"
 end

--- a/lib/how_is/analyzer.rb
+++ b/lib/how_is/analyzer.rb
@@ -142,7 +142,7 @@ class HowIs
         [months, "month"],
         [weeks, "week"],
         [days, "day"],
-      ].reject { |(v, _)| v == 0 }.map { |(v, k)|
+      ].reject { |(v, _)| v.zero? }.map { |(v, k)|
         k += 's' if v != 1
         [v, k]
       }

--- a/lib/how_is/pulse.rb
+++ b/lib/how_is/pulse.rb
@@ -23,7 +23,7 @@ class HowIs
     def html_summary
       parts =
         @pulse_page_response.body
-          .split('<div class="section diffstat-summary">')
+                            .split('<div class="section diffstat-summary">')
 
       if parts.length == 1
         return "There hasn't been any activity on #{@repository} in the last month."

--- a/lib/how_is/pulse.rb
+++ b/lib/how_is/pulse.rb
@@ -14,29 +14,30 @@ class HowIs
       @pulse_page_response = fetch_pulse!(repository)
     end
 
-    # This is probably dead code.
-    def text_summary
-      raise NotImplementedError
-    end
-
     # Gets the HTML Pulse summary.
     def html_summary
-      parts =
-        @pulse_page_response.body
-                            .split('<div class="section diffstat-summary">')
-
-      if parts.length == 1
-        return "There hasn't been any activity on #{@repository} in the last month."
+      if stats_section?
+        stats_html_fragment.gsub('<a href="/', '<a href="https://github.com/')
+      else
+        "There hasn't been any activity on #{@repository} in the last month."
       end
-
-      parts
-        .last
-        .split('</div>').first
-        .gsub('<a href="/', '<a href="https://github.com/')
-        .strip
     end
 
     private
+
+    HTML_SEPARATOR_FOR_STATS = '<div class="section diffstat-summary">'
+
+    def stats_section?
+      parts.count > 1
+    end
+
+    def parts
+      @parts ||= @pulse_page_response.body.split(HTML_SEPARATOR_FOR_STATS)
+    end
+
+    def stats_html_fragment
+      parts.last.split('</div>').first.strip
+    end
 
     # Fetch Pulse page from GitHub for scraping.
     def fetch_pulse!(repository)

--- a/lib/how_is/report/base_report.rb
+++ b/lib/how_is/report/base_report.rb
@@ -129,7 +129,7 @@ class HowIs
       oldest = a.send("oldest_#{type}")
       newest = a.send("newest_#{type}")
 
-      if number_of_type == 0
+      if number_of_type.zero?
         text "There are #{link("no #{type_label}s open", type_link)}."
       else
         text "There #{are_is(number_of_type)} #{link("#{number_of_type} #{pluralize(type_label, number_of_type)} open", type_link)}."

--- a/spec/how_is_spec.rb
+++ b/spec/how_is_spec.rb
@@ -116,7 +116,7 @@ describe HowIs do
       expected = nil
 
       VCR.use_cassette("how-is-example-repository") do
-        actual = HowIs.generate_frontmatter({'foo' => "bar %{baz>"}, {'baz' => "asdf"})
+        actual = HowIs.generate_frontmatter({'foo' => "bar %{baz}"}, {'baz' => "asdf"})
         expected = "---\nfoo: bar asdf\n"
       end
 

--- a/spec/how_is_spec.rb
+++ b/spec/how_is_spec.rb
@@ -109,14 +109,14 @@ describe HowIs do
   end
 
   # Disable 'cop' that is violated by every .generate_frontmatter() calls.
-  # rubocop:disable Style/BracesAroundHashParameters
+  # rubocop:disable Layout/BracesAroundHashParameters
   context '#generate_frontmatter' do
     it 'works with frontmatter parameter using String keys, report_data using String keys' do
       actual = nil
       expected = nil
 
       VCR.use_cassette("how-is-example-repository") do
-        actual = HowIs.generate_frontmatter({'foo' => "bar %{baz}"}, {'baz' => "asdf"})
+        actual = HowIs.generate_frontmatter({'foo' => "bar %<baz>s"}, {'baz' => "asdf"})
         expected = "---\nfoo: bar asdf\n"
       end
 
@@ -128,7 +128,7 @@ describe HowIs do
       expected = nil
 
       VCR.use_cassette("how-is-example-repository") do
-        actual = HowIs.generate_frontmatter({:foo => "bar %{baz}"}, {:baz => "asdf"})
+        actual = HowIs.generate_frontmatter({:foo => "bar %<baz>s"}, {:baz => "asdf"})
         expected = "---\nfoo: bar asdf\n"
       end
 

--- a/spec/how_is_spec.rb
+++ b/spec/how_is_spec.rb
@@ -116,7 +116,7 @@ describe HowIs do
       expected = nil
 
       VCR.use_cassette("how-is-example-repository") do
-        actual = HowIs.generate_frontmatter({'foo' => "bar %<baz>s"}, {'baz' => "asdf"})
+        actual = HowIs.generate_frontmatter({'foo' => "bar %{baz>"}, {'baz' => "asdf"})
         expected = "---\nfoo: bar asdf\n"
       end
 
@@ -128,7 +128,7 @@ describe HowIs do
       expected = nil
 
       VCR.use_cassette("how-is-example-repository") do
-        actual = HowIs.generate_frontmatter({:foo => "bar %<baz>s"}, {:baz => "asdf"})
+        actual = HowIs.generate_frontmatter({:foo => "bar %{baz}"}, {:baz => "asdf"})
         expected = "---\nfoo: bar asdf\n"
       end
 


### PR DESCRIPTION
This PR updates the gem dependency RuboCop to match Hound's. That version is 0.49.1.

Configuration:

- Move newly re-namespaced RuboCop rules into their namespaces
- Make a style choice wrt `Style/FormatStringToken`

Code:

- small refactoring to the `Pulse` class to avoid style issue