### PR TITLE
Include name of rules in RuboCop output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
   TargetRubyVersion: 2.3
   Exclude:
     - 'how_is.gemspec'


### PR DESCRIPTION
When I was working on clarifying style details in another PR, I had to enable two settings to make sense of it.

These are good settings, we should have them on always.