### PR TITLE
Add caching mechanism to speed up duplicate runs

### DIFF
--- a/lib/how_is.rb
+++ b/lib/how_is.rb
@@ -21,11 +21,12 @@ module HowIs
     }
   end
 
-  def self.new(repository, date)
+  def self.new(repository, date, cache_mechanism = nil)
     config =
       Config.new
         .load_defaults
         .load(default_config(repository))
+    config['cache'] = { 'type' => 'self', 'cache_mechanism' => cache_mechanism } if cache_mechanism
     Report.new(config, date)
   end
 

--- a/lib/how_is.rb
+++ b/lib/how_is.rb
@@ -26,7 +26,7 @@ module HowIs
       Config.new
         .load_defaults
         .load(default_config(repository))
-    config['cache'] = { 'type' => 'self', 'cache_mechanism' => cache_mechanism } if cache_mechanism
+    config["cache"] = {"type" => "self", "cache_mechanism" => cache_mechanism} if cache_mechanism
     Report.new(config, date)
   end
 

--- a/lib/how_is/cacheable.rb
+++ b/lib/how_is/cacheable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest"
 
 module HowIs
@@ -16,7 +18,7 @@ module HowIs
       hash_key = []
       hash_key << Digest::SHA1.hexdigest(extra_digest) if extra_digest
       hash_key << Digest::SHA1.hexdigest(@config.to_json)
-      cache_key = File.join(@start_date, @end_date, key, hash_key.join('-'))
+      cache_key = File.join(@start_date, @end_date, key, hash_key.join("-"))
 
       case cache["type"]
       when "marshal"
@@ -39,6 +41,7 @@ module HowIs
     # This is only okay on a local system
     module MarshalCache
       class << self
+        # rubocop:disable Security/MarshalLoad
         def cached(key, config)
           require "fileutils"
 
@@ -47,7 +50,7 @@ module HowIs
 
           ret = nil
           if File.exist?(path)
-            File.open(path,"rb") do |f|
+            File.open(path, "rb") do |f|
               ret = Marshal.load(f)
             end
             ret
@@ -57,8 +60,9 @@ module HowIs
               Marshal.dump(ret, file)
             end
           end
-          ret          
+          ret
         end
+        # rubocop:enable Security/MarshalLoad
 
         private
 

--- a/lib/how_is/cacheable.rb
+++ b/lib/how_is/cacheable.rb
@@ -1,0 +1,96 @@
+require 'digest'
+
+module HowIs
+  class Cacheable
+    def initialize(config, start_date, end_date)
+      @config = config
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def cached(key, extra_digest = nil)
+      cache = @config['cache']
+      return yield if cache.nil?
+
+      hash_key = []
+      hash_key << Digest::SHA1.hexdigest(extra_digest) if extra_digest
+      hash_key << Digest::SHA1.hexdigest(@config.to_json)
+      cache_key = File.join(@start_date, @end_date, key, hash_key.join('-'))
+
+      case cache['type']
+      when 'marshal'
+        MarshalCache.cached(cache_key, @config) { yield }
+      when 'redis'
+        RedisCache.cached(cache_key) { yield }
+      when 'memcache'
+        MemcachedCache.cached(cache_key) { yield }
+      end
+    end
+
+    # This is only okay on a local system
+    module MarshalCache
+      class << self
+        def cached(key, config)
+          require 'fileutils'
+
+          path = File.join(base_cache_dir(config), key)
+          FileUtils.mkdir_p(File.dirname(path))
+
+          if File.exist?(path)
+            ret = nil
+            File.open(path,"rb") do |f|
+              ret = Marshal.load(f)
+            end
+            ret
+          else
+            ret = yield
+            File.open(path, "wb") do |file|
+              Marshal.dump(ret, file)
+            end
+            ret
+          end
+        end
+
+        private
+
+        def base_cache_dir(config)
+          File.join("/tmp/how_is", config['repository'])
+        end
+      end
+    end
+
+    module RedisCache
+      class << self
+        def cached(key, config)
+          require 'redis'
+          redis = Redis.new(cache['config'])
+
+          if o = redis.get(key)
+            Marshal.load(o)
+          else
+            ret = yield
+            redis.set(key, Marshal.dump(ret))
+            ret
+          end
+        end
+      end
+    end
+
+    module MemcacheCache
+      class << self
+        def cached(key, config)
+          require 'memcached'
+          memcache = Memcached.new(cache['config'])
+
+          if o = memcache.get(key)
+            Marshal.load(o)
+          else
+            ret = yield
+            memcache.set(key, Marshal.dump(ret))
+            ret
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/how_is/cacheable.rb
+++ b/lib/how_is/cacheable.rb
@@ -1,6 +1,7 @@
-require 'digest'
+require "digest"
 
 module HowIs
+  # Class for use in caching expensive operations
   class Cacheable
     def initialize(config, start_date, end_date)
       @config = config
@@ -9,7 +10,7 @@ module HowIs
     end
 
     def cached(key, extra_digest = nil)
-      cache = @config['cache']
+      cache = @config["cache"]
       return yield if cache.nil?
 
       hash_key = []
@@ -17,10 +18,10 @@ module HowIs
       hash_key << Digest::SHA1.hexdigest(@config.to_json)
       cache_key = File.join(@start_date, @end_date, key, hash_key.join('-'))
 
-      case cache['type']
-      when 'marshal'
+      case cache["type"]
+      when "marshal"
         MarshalCache.cached(cache_key, @config) { yield }
-      when 'self'
+      when "self"
         # Can provide your own cache in HowIs.new
         # e.g.
         # cache_mechanism = ->(cache_key, config, block) do
@@ -30,8 +31,8 @@ module HowIs
         #     block.call
         #   end
         # end
-        # HowIs.new('owner/repo', date, cache_mechanism)
-        cache['cache_mechanism'].call(cache_key, @config, ->() { yield })
+        # HowIs.new("owner/repo", date, cache_mechanism)
+        cache["cache_mechanism"].call(cache_key, @config, ->() { yield })
       end
     end
 
@@ -39,13 +40,13 @@ module HowIs
     module MarshalCache
       class << self
         def cached(key, config)
-          require 'fileutils'
+          require "fileutils"
 
           path = File.join(base_cache_dir(config), key)
           FileUtils.mkdir_p(File.dirname(path))
 
+          ret = nil
           if File.exist?(path)
-            ret = nil
             File.open(path,"rb") do |f|
               ret = Marshal.load(f)
             end
@@ -55,14 +56,14 @@ module HowIs
             File.open(path, "wb") do |file|
               Marshal.dump(ret, file)
             end
-            ret
           end
+          ret          
         end
 
         private
 
         def base_cache_dir(config)
-          File.join("/tmp/how_is", config['repository'])
+          File.join("/tmp/how_is", config["repository"])
         end
       end
     end

--- a/lib/how_is/report.rb
+++ b/lib/how_is/report.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "how_is/frontmatter"
+require "how_is/cacheable"
 require "how_is/sources/github/contributions"
 require "how_is/sources/github/issues"
 require "how_is/sources/github/pulls"
@@ -31,24 +32,28 @@ module HowIs
       @start_date = start_dt.strftime("%Y-%m-%d")
     end
 
+    def cache
+      @cache ||= Cacheable.new(@config, @start_date, @end_date)
+    end
+
     def contributions
-      @gh_contributions ||= HowIs::Sources::Github::Contributions.new(@config, @start_date, @end_date)
+      @gh_contributions ||= HowIs::Sources::Github::Contributions.new(@config, @start_date, @end_date, cache)
     end
 
     def issues
-      @gh_issues ||= HowIs::Sources::Github::Issues.new(@config, @start_date, @end_date)
+      @gh_issues ||= HowIs::Sources::Github::Issues.new(@config, @start_date, @end_date, cache)
     end
 
     def pulls
-      @gh_pulls ||= HowIs::Sources::Github::Pulls.new(@config, @start_date, @end_date)
+      @gh_pulls ||= HowIs::Sources::Github::Pulls.new(@config, @start_date, @end_date, cache)
     end
 
     def travis
-      @travis ||= HowIs::Sources::CI::Travis.new(@config, @start_date, @end_date)
+      @travis ||= HowIs::Sources::CI::Travis.new(@config, @start_date, @end_date, cache)
     end
 
     def appveyor
-      @appveyor ||= HowIs::Sources::CI::Appveyor.new(@config, @start_date, @end_date)
+      @appveyor ||= HowIs::Sources::CI::Appveyor.new(@config, @start_date, @end_date, cache)
     end
 
     def to_h(frontmatter_data = nil)

--- a/lib/how_is/sources/ci/appveyor.rb
+++ b/lib/how_is/sources/ci/appveyor.rb
@@ -14,7 +14,8 @@ module HowIs
       class Appveyor
         # @param repository [String] GitHub repository name, of the format user/repo.
         # @param start_date [String] Start date for the report being generated.
-        # @param end_date [String] End date for the report being generated.
+        # @param end_date   [String] End date for the report being generated.
+        # @param cache      [Cacheable] Instance of HowIs::Cacheable to cache API calls
         def initialize(config, start_date, end_date, cache)
           @config = config
           @cache = cache

--- a/lib/how_is/sources/ci/travis.rb
+++ b/lib/how_is/sources/ci/travis.rb
@@ -16,7 +16,8 @@ module HowIs
 
         # @param repository [String] GitHub repository name, of the format user/repo.
         # @param start_date [String] Start date for the report being generated.
-        # @param end_date [String] End date for the report being generated.
+        # @param end_date   [String] End date for the report being generated.
+        # @param cache      [Cacheable] Instance of HowIs::Cacheable to cache API calls
         def initialize(config, start_date, end_date, cache)
           @config = config
           @cache = cache

--- a/lib/how_is/sources/github/contributions.rb
+++ b/lib/how_is/sources/github/contributions.rb
@@ -34,9 +34,9 @@ module HowIs
         #                            The first date to include commits from.
         # @param end_date   [String] Date in the format YYYY-MM-DD.
         #                            The last date to include commits from.
+        # @param cache      [Cacheable] Instance of HowIs::Cacheable to cache API calls
         def initialize(config, start_date, end_date, cache)
-          raise "Got String, need Hash. The Github::Contributions API changed." if \
-            config.is_a?(String)
+          raise "Got String, need Hash. The Github::Contributions API changed." if config.is_a?(String)
 
           @config = config
           @cache = cache
@@ -82,19 +82,9 @@ module HowIs
           names = new_contributors.values.map { |c| c["name"] }
           list_items = names.map { |n| "  <li>#{n}</li>" }.join("\n")
 
-          if names.length.zero?
-            num_new_contributors = "no"
-          else
-            num_new_contributors = names.length
-          end
-
-          if names.length == 1
-            was_were = "was"
-            contributor_s = ""
-          else
-            was_were = "were"
-            contributor_s = "s"
-          end
+          num_new_contributors = names.empty? ? "no" : names.length
+          was_were = (names.length == 1) ? "was" : "were"
+          contributor_s = (names.length == 1) ? "" : "s"
 
           Template.apply("new_contributors_partial.html", {
             was_were: was_were,
@@ -147,18 +137,12 @@ module HowIs
         def stats
           return @stats if @stats
 
-          stats = {
-            "total" => 0,
-            "additions" => 0,
-            "deletions" => 0,
-          }
-
+          stats = {"total" => 0, "additions" => 0, "deletions" => 0}
           commits.map do |commit|
             stats.keys.each do |key|
               stats[key] += commit.stats[key]
             end
           end
-
           @stats = stats
         end
 
@@ -166,11 +150,9 @@ module HowIs
           return @changed_files if @changed_files
 
           files = []
-
           commits.map do |commit|
             files += commit.files.map { |file| file["filename"] }
           end
-
           @changed_files = files.sort.uniq
         end
 

--- a/lib/how_is/sources/github/contributions.rb
+++ b/lib/how_is/sources/github/contributions.rb
@@ -71,9 +71,10 @@ module HowIs
             }
             # True if +email+ never wrote a commit for +@repo+ before
             # +@since_date+, false otherwise.
-            @cache.cached("repos_commits", args.to_json) do
+            commits = @cache.cached("repos_commits", args.to_json) do
               @github.repos.commits.list(**args)
-            end.count.zero?
+            end
+            commits.count.zero?
           }
         end
 

--- a/lib/how_is/sources/github/contributions.rb
+++ b/lib/how_is/sources/github/contributions.rb
@@ -16,9 +16,7 @@ module HowIs
       #
       # Usage:
       #
-      #     c = HowIs::Contributions.new(start_date: '2017-07-01',
-      #                                  user: 'how-is',
-      #                                  repo: 'how_is')
+      #     c = HowIs::Contributions.new(start_date: '2017-07-01', user: 'how-is', repo: 'how_is')
       #     c.commits          #=> All commits during July 2017.
       #     c.contributors #=> All contributors during July 2017.
       #     c.new_contributors #=> New contributors during July 2017.
@@ -26,8 +24,7 @@ module HowIs
         include HowIs::Sources::GithubHelpers
 
         # Returns an object that fetches contributor information about a
-        # particular repository for a month-long period starting on
-        # +start_date+.
+        # particular repository for a month-long period starting on +start_date+.
         #
         # @param config     [Hash]   A config object.
         # @param start_date [String] Date in the format YYYY-MM-DD.
@@ -69,8 +66,7 @@ module HowIs
               until: @since_date,
               author: email,
             }
-            # True if +email+ never wrote a commit for +@repo+ before
-            # +@since_date+, false otherwise.
+            # True if +email+ never wrote a commit for +@repo+ before +@since_date+, false otherwise.
             commits = @cache.cached("repos_commits", args.to_json) do
               @github.repos.commits.list(**args)
             end
@@ -82,9 +78,19 @@ module HowIs
           names = new_contributors.values.map { |c| c["name"] }
           list_items = names.map { |n| "  <li>#{n}</li>" }.join("\n")
 
-          num_new_contributors = names.empty? ? "no" : names.length
-          was_were = (names.length == 1) ? "was" : "were"
-          contributor_s = (names.length == 1) ? "" : "s"
+          if names.length.zero?
+            num_new_contributors = "no"
+          else
+            num_new_contributors = names.length
+          end
+
+          if names.length == 1
+            was_were = "was"
+            contributor_s = ""
+          else
+            was_were = "were"
+            contributor_s = "s"
+          end
 
           Template.apply("new_contributors_partial.html", {
             was_were: was_were,

--- a/lib/how_is/sources/github/contributions.rb
+++ b/lib/how_is/sources/github/contributions.rb
@@ -120,7 +120,6 @@ module HowIs
           HowIs::Text.print "Fetching #{@repository} commit data."
 
           # The commits list endpoint doesn't include all stats.
-          #
           # So, to compensate, we make N requests here, where N is number
           # of commits returned, and then we die a bit inside.
           @commits = @cache.cached("repos_commits", args.to_json) do
@@ -130,7 +129,6 @@ module HowIs
             }
           end
           HowIs::Text.puts
-
           @commits
         end
 
@@ -154,10 +152,8 @@ module HowIs
 
         def changed_files
           return @changed_files if @changed_files
-
-          files = []
-          commits.map do |commit|
-            files += commit.files.map { |file| file["filename"] }
+          files = commits.flat_map do |commit|
+            commit.files.map { |file| file["filename"] }
           end
           @changed_files = files.sort.uniq
         end

--- a/lib/how_is/sources/github/issue_fetcher.rb
+++ b/lib/how_is/sources/github/issue_fetcher.rb
@@ -43,6 +43,7 @@ module HowIs
 
         attr_accessor :type
 
+        # @param issues_source [Issues] HowIs::Issues (or HowIs::Pulls) instance for which to fetch issues
         def initialize(issues_source)
           @issues_source = issues_source
           @cache = issues_source.cache

--- a/lib/how_is/sources/github/issue_fetcher.rb
+++ b/lib/how_is/sources/github/issue_fetcher.rb
@@ -52,6 +52,7 @@ module HowIs
           @user, @repo = @repository.split("/", 2)
           @start_date = issues_source.start_date
           @end_date = issues_source.end_date
+          @type = issues_source.type
         end
 
         def data
@@ -62,9 +63,8 @@ module HowIs
 
           HowIs::Text.print "Fetching #{@repository} #{@issues_source.pretty_type} data."
 
-          @data = @cache.cached(type) do
+          @data = @cache.cached("fetch-#{type}") do
             data = []
-            after = nil
             after, data = fetch_issues(after, data) until after == END_LOOP
             data.select(&method(:issue_is_relevant?))
           end

--- a/lib/how_is/sources/github/issue_fetcher.rb
+++ b/lib/how_is/sources/github/issue_fetcher.rb
@@ -43,8 +43,9 @@ module HowIs
 
         attr_accessor :type
 
-        def initialize(config, type, start_date, end_date)
+        def initialize(config, type, start_date, end_date, cache)
           @config = config
+          @cache = cache
           @github = HowIs::Sources::Github.new(config)
           @repository = config["repository"]
           @user, @repo = @repository.split("/", 2)
@@ -61,9 +62,12 @@ module HowIs
 
           HowIs::Text.print "Fetching #{@repository} #{(type == 'issues') ? 'issue' : 'PR'} data."
 
-          after = nil
-          data = []
-          after, data = fetch_issues(after, data) until after == END_LOOP
+          data = @cache.cached(type) do
+            data = []
+            after = nil
+            after, data = fetch_issues(after, data) until after == END_LOOP
+            data
+          end
 
           HowIs::Text.puts
 

--- a/lib/how_is/sources/github/issue_fetcher.rb
+++ b/lib/how_is/sources/github/issue_fetcher.rb
@@ -43,15 +43,14 @@ module HowIs
 
         attr_accessor :type
 
-        def initialize(config, type, start_date, end_date, cache)
-          @config = config
-          @cache = cache
-          @github = HowIs::Sources::Github.new(config)
-          @repository = config["repository"]
+        def initialize(issues_source)
+          @issues_source = issues_source
+          @cache = issues_source.cache
+          @github = HowIs::Sources::Github.new(issues_source.config)
+          @repository = issues_source.config["repository"]
           @user, @repo = @repository.split("/", 2)
-          @start_date = start_date
-          @end_date = end_date
-          @type = type
+          @start_date = issues_source.start_date
+          @end_date = issues_source.end_date
         end
 
         def data
@@ -60,18 +59,18 @@ module HowIs
           @data = []
           return @data if last_cursor.nil?
 
-          HowIs::Text.print "Fetching #{@repository} #{(type == 'issues') ? 'issue' : 'PR'} data."
+          HowIs::Text.print "Fetching #{@repository} #{@issues_source.pretty_type} data."
 
-          data = @cache.cached(type) do
+          @data = @cache.cached(type) do
             data = []
             after = nil
             after, data = fetch_issues(after, data) until after == END_LOOP
-            data
+            data.select(&method(:issue_is_relevant?))
           end
 
           HowIs::Text.puts
 
-          @data = data.select(&method(:issue_is_relevant?))
+          @data
         end
 
         def issue_is_relevant?(issue)

--- a/lib/how_is/sources/github/issues.rb
+++ b/lib/how_is/sources/github/issues.rb
@@ -16,8 +16,9 @@ module HowIs
         include HowIs::DateTimeHelpers
         include HowIs::Sources::GithubHelpers
 
-        def initialize(config, start_date, end_date)
+        def initialize(config, start_date, end_date, cache)
           @config = config
+          @cache = cache
           @repository = config["repository"]
           raise "#{self.class}.new() got nil repository." if @repository.nil?
           @start_date = start_date
@@ -110,7 +111,7 @@ module HowIs
         def data
           return @data if instance_variable_defined?(:@data)
 
-          fetcher = IssueFetcher.new(@config, type, @start_date, @end_date)
+          fetcher = IssueFetcher.new(@config, type, @start_date, @end_date, @cache)
           @data = fetcher.data
         end
       end

--- a/lib/how_is/sources/github/issues.rb
+++ b/lib/how_is/sources/github/issues.rb
@@ -18,6 +18,10 @@ module HowIs
 
         attr_reader :config, :start_date, :end_date, :cache
 
+        # @param repository [String] GitHub repository name, of the format user/repo.
+        # @param start_date [String] Start date for the report being generated.
+        # @param end_date   [String] End date for the report being generated.
+        # @param cache      [Cacheable] Instance of HowIs::Cacheable to cache API calls
         def initialize(config, start_date, end_date, cache)
           @config = config
           @cache = cache

--- a/lib/how_is/sources/github/issues.rb
+++ b/lib/how_is/sources/github/issues.rb
@@ -16,6 +16,8 @@ module HowIs
         include HowIs::DateTimeHelpers
         include HowIs::Sources::GithubHelpers
 
+        attr_reader :config, :start_date, :end_date, :cache
+
         def initialize(config, start_date, end_date, cache)
           @config = config
           @cache = cache
@@ -90,6 +92,14 @@ module HowIs
           obj_to_array_of_hashes(data)
         end
 
+        def type
+          singular_type + "s"
+        end
+
+        def pretty_type
+          "issue"
+        end
+
         private
 
         def url_suffix
@@ -100,18 +110,10 @@ module HowIs
           "issue"
         end
 
-        def type
-          singular_type + "s"
-        end
-
-        def pretty_type
-          "issue"
-        end
-
         def data
           return @data if instance_variable_defined?(:@data)
 
-          fetcher = IssueFetcher.new(@config, type, @start_date, @end_date, @cache)
+          fetcher = IssueFetcher.new(self)
           @data = fetcher.data
         end
       end

--- a/spec/how_is/builds_spec.rb
+++ b/spec/how_is/builds_spec.rb
@@ -5,11 +5,8 @@ require "how_is/sources/ci/appveyor"
 
 describe HowIs::Sources::CI::Travis do
   subject do
-    config =
-      HowIs::Config.new
-        .load_defaults
-        .load({"repository" => "how-is/how_is"})
-    described_class.new(config, "2018-03-01", "2017-04-15")
+    cache = cache("2018-03-01", "2017-04-15")
+    described_class.new(config("how-is/how_is"), "2018-03-01", "2017-04-15", cache)
   end
 
   describe "#builds" do
@@ -24,6 +21,9 @@ describe HowIs::Sources::CI::Travis do
         ENV["HOWIS_GITHUB_TOKEN"] = token
         ENV["HOWIS_GITHUB_USERNAME"] = username
       end
+
+      # This will fail without VCR if the cache isn't working
+      expect(subject.builds).to be_a(Array)
     end
 
     it "returns an Array" do

--- a/spec/how_is/builds_spec.rb
+++ b/spec/how_is/builds_spec.rb
@@ -11,16 +11,7 @@ describe HowIs::Sources::CI::Travis do
 
   describe "#builds" do
     around(:example) do |example|
-      token = ENV["HOWIS_GITHUB_TOKEN"]
-      username = ENV["HOWIS_GITHUB_USERNAME"]
-      begin
-        ENV["HOWIS_GITHUB_TOKEN"] = "blah"
-        ENV["HOWIS_GITHUB_USERNAME"] = "who"
-        example.run
-      ensure
-        ENV["HOWIS_GITHUB_TOKEN"] = token
-        ENV["HOWIS_GITHUB_USERNAME"] = username
-      end
+      load_test_env { example.run }
 
       # This will fail without VCR if the cache isn't working
       expect(subject.builds).to be_a(Array)

--- a/spec/how_is/cacheable_spec.rb
+++ b/spec/how_is/cacheable_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "how_is/cacheable"
+
+describe HowIs::Cacheable do
+  let(:marshal_cache_config) do
+    config =
+      HowIs::Config.new
+        .load_defaults
+        .load({"repository" => "how-is/how_is", "cache" => {"type" => "marshal"}})
+  end
+
+  CACHE_HASH = {}
+  let(:self_cache_config) do
+    config =
+      HowIs::Config.new
+        .load_defaults
+        .load({
+          "repository" => "how-is/how_is",
+          "cache" => {
+            "type" => "self",
+            "cache_mechanism" => ->(cache_key, _, block) {
+              CACHE_HASH[cache_key] ||= block.call
+            }
+          }
+        })
+  end
+
+  let(:no_cache_config) do
+    config =
+      HowIs::Config.new
+        .load_defaults
+        .load({"repository" => "how-is/how_is"})
+  end
+
+  describe "#cached" do
+    it "caches with Marshal" do
+      marshal_cache = described_class.new(marshal_cache_config, "2018-03-01", "2017-04-15")
+      x = 0
+      2.times do
+        marshal_cache.cached("marshal_cache") do
+          x += 1
+        end
+      end
+      expect(x).to eq(1)
+    end
+
+    it "caches with self" do
+      self_cache = described_class.new(self_cache_config, "2018-03-01", "2017-04-15")
+
+      x = 0
+      2.times do
+        self_cache.cached("self_cache") do
+          x += 1
+        end
+      end
+      expect(x).to eq(1)
+
+      digest = Digest::SHA1.hexdigest(self_cache_config.to_json)
+      key = "2018-03-01/2017-04-15/self_cache/#{digest}"
+      expect(CACHE_HASH[key]).to eq(1)
+    end
+
+    it "caches only when opted in" do
+      no_cache = described_class.new(no_cache_config, "2018-03-01", "2017-04-15")
+      x = 0
+      2.times do
+        no_cache.cached("no_cache") do
+          x += 1 # Will be run twice
+        end
+      end
+      expect(x).to eq(2)
+    end
+  end
+end

--- a/spec/how_is/cacheable_spec.rb
+++ b/spec/how_is/cacheable_spec.rb
@@ -3,6 +3,12 @@
 require "how_is/cacheable"
 
 describe HowIs::Cacheable do
+  around(:example) do |example|
+    load_test_env do
+      example.run
+    end
+  end
+
   let(:marshal_cache_config) do
     config =
       HowIs::Config.new

--- a/spec/how_is/contributions_spec.rb
+++ b/spec/how_is/contributions_spec.rb
@@ -5,11 +5,8 @@ require "how_is/sources/github/contributions"
 
 describe HowIs::Sources::Github::Contributions, skip: env_vars_hidden? do
   let(:contributions) {
-    config =
-      HowIs::Config.new
-        .load_defaults
-        .load({"repository" => "how-is/example-repository"})
-    described_class.new(config, "2017-08-01", "2017-09-01")
+    cache = cache("2017-08-01", "2017-09-01")
+    described_class.new(config("how-is/example-repository"), "2017-08-01", "2017-09-01", cache)
   }
 
   context "#contributors" do
@@ -19,6 +16,11 @@ describe HowIs::Sources::Github::Contributions, skip: env_vars_hidden? do
           match_array(["me@duckie.co", "fake@duckinator.net"])
         )
       end
+
+      # This will fail without VCR if the cache isn't working
+      expect(contributions.contributors.keys).to(
+        match_array(["me@duckie.co", "fake@duckinator.net"])
+      )
     end
   end
 
@@ -31,6 +33,11 @@ describe HowIs::Sources::Github::Contributions, skip: env_vars_hidden? do
           match_array(["fake@duckinator.net"])
         )
       end
+
+      # This will fail without VCR if the cache isn't working
+      expect(contributions.new_contributors.keys).to(
+        match_array(["fake@duckinator.net"])
+      )
     end
   end
 
@@ -46,6 +53,9 @@ describe HowIs::Sources::Github::Contributions, skip: env_vars_hidden? do
           "8286e548e330cfe01efcf7189f4df1fa53e777a7",
         ])
       end
+
+      # This will fail without VCR if the cache isn't working
+      contributions.commits
     end
   end
 
@@ -63,6 +73,9 @@ describe HowIs::Sources::Github::Contributions, skip: env_vars_hidden? do
         })
         expect(files).to eq(["README.md"])
       end
+
+      # This will fail without VCR if the cache isn't working
+      contributions.changes
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,3 +25,16 @@ end
 def cache(start_date, end_date)
   HowIs::Cacheable.new(config("how-is/how_is"), start_date, end_date)
 end
+
+def load_test_env
+  token = ENV["HOWIS_GITHUB_TOKEN"]
+  username = ENV["HOWIS_GITHUB_USERNAME"]
+  begin
+    ENV["HOWIS_GITHUB_TOKEN"] = "blah"
+    ENV["HOWIS_GITHUB_USERNAME"] = "who"
+    yield
+  ensure
+    ENV["HOWIS_GITHUB_TOKEN"] = token
+    ENV["HOWIS_GITHUB_USERNAME"] = username
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,16 @@ def env_vars_hidden?
   travis_pr = ENV["TRAVIS_PULL_REQUEST"]
   !travis_pr.nil? && (travis_pr != "false")
 end
+
+def config(repo)
+  HowIs::Config.new
+    .load_defaults
+    .load({
+      "repository" => repo,
+      "cache" => { "type" => "marshal" }
+    })
+end
+
+def cache(start_date, end_date)
+  HowIs::Cacheable.new(config("how-is/how_is"), start_date, end_date)
+end


### PR DESCRIPTION
When you perform a run of how_is, you may include the same data. E.g. the same commits are fetched, or you run the same build multiple times. This gives an option to specify your own cache mechanism, for example on a webserver with redis or memcache